### PR TITLE
feat: add gas cost tracking and forecasting

### DIFF
--- a/lib/gas.ts
+++ b/lib/gas.ts
@@ -1,0 +1,13 @@
+export async function scrapeGasPrice(stationId: string): Promise<number | null> {
+  try {
+    const res = await fetch(`https://www.gasbuddy.com/station/${stationId}`);
+    const html = await res.text();
+    const match = html.match(/"regular"\s*:\s*\{[^}]*"price"\s*:\s*(\d+\.\d+)/i);
+    if (match) {
+      return parseFloat(match[1]);
+    }
+  } catch (err) {
+    console.error('Failed to fetch gas price', err);
+  }
+  return null;
+}

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -64,3 +64,26 @@ GRANT ALL ON public.odometer_logs TO authenticated;
 GRANT ALL ON public.trip_events TO authenticated;
 GRANT ALL ON public.odometer_logs TO anon;
 GRANT ALL ON public.trip_events TO anon;
+
+-- Create gas_prices table
+CREATE TABLE IF NOT EXISTS public.gas_prices (
+    id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+    station_id TEXT NOT NULL,
+    price NUMERIC(6,3) NOT NULL,
+    recorded_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_gas_prices_station_time
+ON public.gas_prices (station_id, recorded_at);
+
+ALTER TABLE public.gas_prices ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow anonymous access to gas_prices" ON public.gas_prices;
+
+CREATE POLICY "Allow anonymous access to gas_prices"
+ON public.gas_prices FOR ALL
+TO anon, authenticated
+USING (true) WITH CHECK (true);
+
+GRANT ALL ON public.gas_prices TO authenticated;
+GRANT ALL ON public.gas_prices TO anon;


### PR DESCRIPTION
## Summary
- scrape GasBuddy station price and persist to Supabase
- track historical gas prices and compute spent/forecast costs
- display gas cost stats and chart above lease information

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68b467cf22c0832fb250aaeae8ee2c6e