### PR TITLE
Fix gas price scraping by adding server API proxy

### DIFF
--- a/app/api/gas-price/route.ts
+++ b/app/api/gas-price/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { scrapeGasPrice } from '../../../lib/gas';
+
+export async function GET(req: NextRequest) {
+  const stationId = req.nextUrl.searchParams.get('stationId');
+  if (!stationId) {
+    return NextResponse.json({ error: 'stationId query parameter is required' }, { status: 400 });
+  }
+
+  const price = await scrapeGasPrice(stationId);
+  if (price == null) {
+    return NextResponse.json({ error: 'Failed to fetch gas price' }, { status: 500 });
+  }
+
+  return NextResponse.json({ price });
+}

--- a/components/MilesTracker.tsx
+++ b/components/MilesTracker.tsx
@@ -12,7 +12,6 @@ import { format, parseISO, differenceInDays, startOfDay, subDays } from 'date-fn
 import { Progress } from './ui/progress';
 import { env } from '../lib/env';
 import ThemeToggle from './ThemeToggle';
-import { scrapeGasPrice } from '../lib/gas';
 
 // Types
 interface OdometerReading {
@@ -127,7 +126,9 @@ export default function MilesTracker() {
       setPriceHistory(history || []);
 
       const latest = history && history.length > 0 ? history[history.length - 1].price : null;
-      const fetched = await scrapeGasPrice(stationId);
+      const res = await fetch(`/api/gas-price?stationId=${stationId}`);
+      const fetchedData = res.ok ? await res.json() : null;
+      const fetched = fetchedData?.price as number | undefined;
       const price = fetched ?? latest;
       if (price != null) {
         setGasPrice(price);

--- a/lib/gas.ts
+++ b/lib/gas.ts
@@ -1,8 +1,14 @@
 export async function scrapeGasPrice(stationId: string): Promise<number | null> {
   try {
-    const res = await fetch(`https://www.gasbuddy.com/station/${stationId}`);
+    const res = await fetch(`https://www.gasbuddy.com/station/${stationId}`, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36',
+        'Accept-Language': 'en-US,en;q=0.9'
+      }
+    });
     const html = await res.text();
-    const match = html.match(/"regular"\s*:\s*\{[^}]*"price"\s*:\s*(\d+\.\d+)/i);
+    const match = html.match(/<span[^>]*FuelTypePriceDisplay-module__price[^>]*>\$(\d+\.\d{2})<\/span>/i);
     if (match) {
       return parseFloat(match[1]);
     }


### PR DESCRIPTION
## Summary
- Add server-side gas price scraper with User-Agent headers and DOM parsing
- Expose `/api/gas-price` route and use it from MilesTracker component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: asks for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68b4729b75cc832fa0f2c972ef05d406