### PR TITLE
feat: persist vehicle mpg for gas forecasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ npm run dev
 
 ## Database Schema
 
-The app uses two main tables:
+The app uses three main tables:
 
 ### `odometer_logs`
 - Records vehicle odometer readings with dates
@@ -88,6 +88,10 @@ The app uses two main tables:
 - Tracks upcoming trips that will impact mileage
 - Helps adjust forecasting for planned travel
 - Includes estimated miles for each event
+
+### `vehicles`
+- Stores per-vehicle settings such as miles-per-gallon
+- Enables gas cost forecasts tailored to each vehicle
 
 ## Usage
 

--- a/supabase-schema.sql
+++ b/supabase-schema.sql
@@ -65,6 +65,25 @@ GRANT ALL ON public.trip_events TO authenticated;
 GRANT ALL ON public.odometer_logs TO anon;
 GRANT ALL ON public.trip_events TO anon;
 
+-- Create vehicles table
+CREATE TABLE IF NOT EXISTS public.vehicles (
+    id TEXT PRIMARY KEY,
+    name TEXT,
+    mpg NUMERIC(6,3)
+);
+
+ALTER TABLE public.vehicles ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Allow anonymous access to vehicles" ON public.vehicles;
+
+CREATE POLICY "Allow anonymous access to vehicles"
+ON public.vehicles FOR ALL
+TO anon, authenticated
+USING (true) WITH CHECK (true);
+
+GRANT ALL ON public.vehicles TO authenticated;
+GRANT ALL ON public.vehicles TO anon;
+
 -- Create gas_prices table
 CREATE TABLE IF NOT EXISTS public.gas_prices (
     id UUID DEFAULT gen_random_uuid() PRIMARY KEY,


### PR DESCRIPTION
## Summary
- store vehicle miles-per-gallon in new `vehicles` table
- load and save per-vehicle MPG in `MilesTracker` to drive gas cost forecasts
- document new table and purpose in README

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive configuration)
- `npm run build` (fails: Failed to fetch `Inter` font from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b7000c274c832fa47414026df5b2c1