### PR TITLE
Refine dark theme with violet accent gradient

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,15 +24,15 @@
     --input: 214.3 31.8% 91.4%;
     --ring: 222.2 84% 4.9%;
     --radius: 0.5rem;
-    /* Accent hues for glow theme (blue/orange) */
+    /* Accent hues for glow theme (blue/violet) */
     --glow-blue: 217 91% 60%; /* around tailwind blue-500 */
     --glow-blue-soft: 217 91% 60% / 0.25;
-    --glow-orange: 24 95% 53%; /* around orange-500 */
-    --glow-orange-soft: 24 95% 53% / 0.25;
+    --glow-violet: 262 83% 58%; /* around violet-500 */
+    --glow-violet-soft: 262 83% 58% / 0.25;
   }
  
   .dark {
-    /* Dark palette tuned for subtle blue/orange glow */
+    /* Dark palette tuned for subtle blue/violet glow */
     --background: 222 50% 5%;
     --foreground: 210 40% 96%;
     --card: 222 50% 6.5%;
@@ -45,7 +45,7 @@
     --secondary-foreground: 210 40% 96%;
     --muted: 222 35% 12%;
     --muted-foreground: 215 16% 72%;
-    --accent: 24 95% 53%; /* orange as secondary accent */
+    --accent: 262 83% 58%; /* violet as secondary accent */
     --accent-foreground: 222 50% 6%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%;
@@ -60,14 +60,15 @@
     @apply border-border;
   }
   body {
-    /* Subtle radial gradient and background grid for depth */
+    /* Subtle gradient inspired by modern finance dashboards */
     @apply bg-background text-foreground;
     background-image:
       radial-gradient(1200px 600px at 0% -10%, hsl(var(--glow-blue-soft)) 0%, transparent 60%),
-      radial-gradient(800px 400px at 100% 110%, hsl(var(--glow-orange-soft)) 0%, transparent 65%),
-      linear-gradient(to bottom, transparent, transparent 100%);
+      radial-gradient(800px 400px at 100% 110%, hsl(var(--glow-violet-soft)) 0%, transparent 65%),
+      linear-gradient(180deg, hsl(222 45% 7%), hsl(264 44% 12%));
     background-size: cover;
     background-repeat: no-repeat;
+    background-attachment: fixed;
   }
 }
 
@@ -81,10 +82,13 @@
       0 0 12px hsl(var(--glow-blue-soft)),
       0 0 24px hsl(var(--glow-blue-soft));
   }
-  .glow-orange:hover {
+  .glow-violet {
+    box-shadow: 0 0 0 0 rgba(0,0,0,0);
+  }
+  .glow-violet:hover {
     box-shadow:
-      0 0 12px hsl(var(--glow-orange-soft)),
-      0 0 24px hsl(var(--glow-orange-soft));
+      0 0 12px hsl(var(--glow-violet-soft)),
+      0 0 24px hsl(var(--glow-violet-soft));
   }
   .glass-card {
     background: linear-gradient(

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -118,13 +118,13 @@ export default function SettingsPage() {
     <div className="container mx-auto p-6 space-y-6">
       <div className="mb-6 flex items-center justify-between">
         <div>
-          <h1 className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-blue-300 to-orange-300">
+          <h1 className="text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-indigo-300 to-purple-300">
             Settings
           </h1>
           <p className="text-muted-foreground mt-2">Configure your vehicle and lease preferences</p>
         </div>
         <div className="flex items-center gap-2">
-          <Button asChild variant="outline" className="glow-orange">
+          <Button asChild variant="outline">
             <Link href="/">Back to Dashboard</Link>
           </Button>
           <ThemeToggle />

--- a/components/MilesTracker.tsx
+++ b/components/MilesTracker.tsx
@@ -756,7 +756,7 @@ export default function MilesTracker() {
       <div className="mb-8">
         <div className="flex items-center justify-between">
           <div>
-            <h1 className="hidden md:block text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-blue-300 to-orange-300">
+            <h1 className="hidden md:block text-3xl font-bold bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-indigo-300 to-purple-300">
               Miles Ahead 🚗💎
             </h1>
             <p className="hidden md:block text-muted-foreground mt-2">
@@ -764,7 +764,7 @@ export default function MilesTracker() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            <Button asChild variant="outline" className="glow-orange"><Link href="/settings">Settings</Link></Button>
+            <Button asChild variant="outline"><Link href="/settings">Settings</Link></Button>
             <ThemeToggle />
           </div>
         </div>

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         destructive:
           "bg-destructive text-destructive-foreground hover:bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground hover:glow-orange",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground glow-violet",
         secondary:
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",


### PR DESCRIPTION
## Summary
- adjust global theme to use blue/violet accents and gradient background
- update button outline variant with reusable violet hover glow
- align dashboard and settings headers with new purple gradient

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb57896b54832f90e02d8272f0589a