### PR TITLE
feat: add lease days progress bar

### DIFF
--- a/components/MilesTracker.tsx
+++ b/components/MilesTracker.tsx
@@ -769,6 +769,14 @@ export default function MilesTracker() {
   });
 
   const stats: StatsObject = calculateStats();
+  const totalLeaseDays = differenceInDays(
+    vehicleConfig.leaseEndDate,
+    vehicleConfig.leaseStartDate
+  );
+  const leaseProgressPercent = Math.min(
+    100,
+    Math.max(0, (stats.daysIntoLease / totalLeaseDays) * 100)
+  );
   const chartData = prepareChartData(timeRange);
   const forecastData = prepareForecastData();
   const lineDomain = React.useMemo(() => {
@@ -1354,8 +1362,9 @@ export default function MilesTracker() {
           </div>
           <div className="flex justify-between">
             <span>Days into Lease:</span>
-            <span>{Math.max(0, stats.daysIntoLease)} days of {differenceInDays(vehicleConfig.leaseEndDate, vehicleConfig.leaseStartDate)} days</span>
+            <span>{Math.max(0, stats.daysIntoLease)} days of {totalLeaseDays} days</span>
           </div>
+          <Progress value={leaseProgressPercent} className="h-2" />
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- calculate lease duration progress
- display lease progress bar in lease information

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in components/PasswordProtection.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68c44e1df6b0832fa83a1985e831f473