### PR TITLE
Fix mileage progress scale display

### DIFF
--- a/components/MilesTracker.tsx
+++ b/components/MilesTracker.tsx
@@ -60,9 +60,7 @@ interface CenteredProgress {
 }
 
 const calculateCenteredProgress = (value: number): CenteredProgress => {
-  const magnitude = Math.abs(value);
-  const multiplier = magnitude === 0 ? 1 : Math.ceil(magnitude / BASE_PROGRESS_RANGE);
-  const range = Math.max(BASE_PROGRESS_RANGE, multiplier * BASE_PROGRESS_RANGE);
+  const range = BASE_PROGRESS_RANGE;
   const credit = value > 0 ? value : 0;
   const debt = value < 0 ? Math.abs(value) : 0;
 


### PR DESCRIPTION
## Summary
- keep the mileage balance progress scale fixed at 660 miles by removing the dynamic range expansion

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db266de79c832faac6981f0b154f5a