### PR TITLE
Fix weekly allowance tooltip label

### DIFF
--- a/components/MilesTracker.tsx
+++ b/components/MilesTracker.tsx
@@ -1182,9 +1182,9 @@ export default function MilesTracker() {
                       <XAxis dataKey="label" stroke="#94a3b8" tick={{ fill: '#94a3b8' }} />
                       <YAxis stroke="#94a3b8" tick={{ fill: '#94a3b8' }} />
                       <Tooltip
-                        formatter={(value: number, name: string) => [
+                        formatter={(value: number, _name: string, info: any) => [
                           `${Math.round(value).toLocaleString()} miles`,
-                          name === 'allowance' ? 'Weekly Allowance' : 'Actual Miles'
+                          info?.dataKey === 'allowance' ? 'Weekly Allowance' : 'Actual Miles'
                         ]}
                       />
                       <Legend />


### PR DESCRIPTION
## Summary
- ensure the weekly mileage trend tooltip correctly labels the allowance series

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df20e68530832f8aeab5a7192ba5a2